### PR TITLE
docs: fix image paths in README for icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A website by Yonatan Ben Knaan
 
-![kof-icon](kof-icon.svg#gh-light-mode-only)
-![kof-icon-dark](kof-icon-dark.svg#gh-dark-mode-only)
+![kof-icon](/kof-icon.svg#gh-light-mode-only)
+![kof-icon-dark](/kof-icon-dark.svg#gh-dark-mode-only)
 
 ## Links
 


### PR DESCRIPTION
Update icon image paths in the README to use absolute paths.   This ensures the icons display correctly in both light and dark   modes across different environments.